### PR TITLE
feat: add --version flag to display version information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ BINARY_NAME=spemu
 MAIN_PATH=.
 PKG_LIST := $(shell go list ./...)
 TEST_PKG_LIST := $(shell go list ./pkg/...)
+VERSION := $(shell cat version.txt)
 
 # Default target
 help: ## Show this help message
@@ -23,17 +24,17 @@ dev-setup: ## Install development dependencies
 # Build targets
 build: ## Build the binary
 	@echo "Building $(BINARY_NAME)..."
-	go build -o $(BINARY_NAME) $(MAIN_PATH)
+	go build -ldflags "-X main.Version=$(VERSION)" -o $(BINARY_NAME) $(MAIN_PATH)
 
 build-all: ## Build for all platforms
 	@echo "Building for multiple platforms..."
-	GOOS=linux GOARCH=amd64 go build -o $(BINARY_NAME)-linux-amd64 $(MAIN_PATH)
-	GOOS=darwin GOARCH=amd64 go build -o $(BINARY_NAME)-darwin-amd64 $(MAIN_PATH)
-	GOOS=darwin GOARCH=arm64 go build -o $(BINARY_NAME)-darwin-arm64 $(MAIN_PATH)
-	GOOS=windows GOARCH=amd64 go build -o $(BINARY_NAME)-windows-amd64.exe $(MAIN_PATH)
+	GOOS=linux GOARCH=amd64 go build -ldflags "-X main.Version=$(VERSION)" -o $(BINARY_NAME)-linux-amd64 $(MAIN_PATH)
+	GOOS=darwin GOARCH=amd64 go build -ldflags "-X main.Version=$(VERSION)" -o $(BINARY_NAME)-darwin-amd64 $(MAIN_PATH)
+	GOOS=darwin GOARCH=arm64 go build -ldflags "-X main.Version=$(VERSION)" -o $(BINARY_NAME)-darwin-arm64 $(MAIN_PATH)
+	GOOS=windows GOARCH=amd64 go build -ldflags "-X main.Version=$(VERSION)" -o $(BINARY_NAME)-windows-amd64.exe $(MAIN_PATH)
 
 install: ## Install the binary to GOPATH/bin
-	go install .
+	go install -ldflags "-X main.Version=$(VERSION)" .
 
 # Code quality targets
 fmt: ## Format Go code

--- a/main.go
+++ b/main.go
@@ -11,11 +11,15 @@ import (
 	"github.com/nu0ma/spemu/pkg/parser"
 )
 
+// Version is set during build time via ldflags
+var Version = "dev"
+
 func main() {
 	var (
 		dryRun    = flag.Bool("dry-run", false, "Parse and validate DML without executing")
 		verbose   = flag.Bool("verbose", false, "Enable verbose output")
 		help      = flag.Bool("help", false, "Show help message")
+		version   = flag.Bool("version", false, "Show version information")
 		project   = flag.String("project", "", "Spanner project ID (required)")
 		projectS  = flag.String("p", "", "Spanner project ID (short form)")
 		instance  = flag.String("instance", "", "Spanner instance ID (required)")
@@ -26,6 +30,11 @@ func main() {
 		portS     = flag.String("P", "9010", "Spanner emulator port (short form)")
 	)
 	flag.Parse()
+
+	if *version {
+		fmt.Printf("spemu version %s\n", Version)
+		return
+	}
 
 	if *help {
 		showHelp()
@@ -126,6 +135,7 @@ Options:
   --port, -P       Spanner emulator port (default: 9010)
   --dry-run        Parse and validate DML without executing
   --verbose        Enable verbose output
+  --version        Show version information
   --help           Show this help message
 
 Examples:


### PR DESCRIPTION
## Summary
- Add `--version` flag that displays current version information
- Update Makefile to inject version from version.txt during build using ldflags
- Update help text to include the new version option

## Test plan
- [x] Build binary with `make build`
- [x] Test `spemu --version` displays correct version (0.2.0)
- [x] Test `spemu --help` shows version option in help text
- [x] Verify version is properly injected during build process