### PR TITLE
docs: clarify that spemu does not require gcloud CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A command-line tool for inserting DML (Data Manipulation Language) statements in
 - Dry run mode for validation
 - Verbose output for debugging
 - Integration with Spanner Emulator
+- No dependency on `gcloud` CLI (uses Go client libraries directly)
 - Comprehensive test suite with CI/CD
 
 ## Installation
@@ -82,6 +83,8 @@ DELETE FROM users WHERE id = 2;
 
 - Go 1.21 or later
 - Docker and Docker Compose
+
+**Note:** spemu does not require the `gcloud` CLI tool. It connects directly to the Spanner Emulator using Go client libraries.
 
 ### Setup Development Environment
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ A command-line tool for inserting DML (Data Manipulation Language) statements in
 
 ## Features
 
+- No dependency on `gcloud` CLI
 - Parse and execute DML files (INSERT, UPDATE, DELETE statements)
 - Support for SQL comments (`--` style)
 - Dry run mode for validation
 - Verbose output for debugging
 - Integration with Spanner Emulator
-- No dependency on `gcloud` CLI (uses Go client libraries directly)
 - Comprehensive test suite with CI/CD
 
 ## Installation

--- a/scripts/setup-emulator.sh
+++ b/scripts/setup-emulator.sh
@@ -14,12 +14,6 @@ check_dependencies() {
         exit 1
     fi
     
-    if ! command -v gcloud &> /dev/null; then
-        echo "Error: gcloud CLI is required but not installed"
-        echo "Please install Google Cloud SDK: https://cloud.google.com/sdk/docs/install"
-        exit 1
-    fi
-    
     if ! command -v nc &> /dev/null; then
         echo "Error: nc (netcat) is required but not installed"
         echo "Please install netcat: apt-get install netcat (Debian/Ubuntu) or brew install netcat (macOS)"


### PR DESCRIPTION
## Summary
- Add clear note to README.md that spemu does not require gcloud CLI installation
- Remove unnecessary gcloud dependency check from setup-emulator.sh script
- Align documentation with actual implementation (spemu uses Go client libraries directly)

## Test plan
- [x] Verify README.md clearly states no gcloud dependency
- [x] Confirm setup script no longer checks for gcloud
- [x] Validate that emulator setup still works without gcloud installed