### PR TITLE
fix: remove git plugin to avoid repository rule violations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,6 @@ jobs:
         id: semantic
         with:
           semantic_version: 22
-          extra_plugins: |
-            @semantic-release/changelog@6.0.3
-            @semantic-release/git@10.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -4,19 +4,6 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    [
-      "@semantic-release/changelog",
-      {
-        "changelogFile": "CHANGELOG.md"
-      }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["CHANGELOG.md"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-      }
-    ],
     "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
## Summary
Fix GitHub Actions release workflow failure caused by repository rule violations.

## Problem
The semantic-release workflow was failing because:
- `@semantic-release/git` plugin tried to push commits back to main branch
- Repository rules prevent direct pushes to main (requires PR)
- Error: `Changes must be made through a pull request`

## Solution
- Remove `@semantic-release/changelog` and `@semantic-release/git` plugins
- Keep only `@semantic-release/github` for creating releases
- No more commits pushed back to main branch

## Test Plan
- [ ] Merge this PR to test the fixed workflow
- [ ] Verify release is created successfully without repository rule violations
- [ ] Confirm binaries are built and uploaded correctly

This is a follow-up fix for the git-based versioning implementation.