### PR TITLE
feat: configure GoReleaser to create PRs for Homebrew formula updates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+# Pull Request
+
+## Summary
+Brief description of the changes made in this pull request.
+
+## Type of Change
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Homebrew formula update (automated release)
+
+## Changes Made
+- List the specific changes made
+
+## Testing
+- [ ] I have tested these changes locally
+- [ ] All existing tests pass
+- [ ] New tests have been added (if applicable)
+
+## For Homebrew Formula Updates
+- [ ] Version number is correct
+- [ ] Download URL is accessible
+- [ ] SHA256 checksum is correct
+- [ ] Formula installs successfully
+- [ ] Binary executes and shows help correctly
+
+## Additional Notes
+Any additional information that would be helpful for the reviewer.

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -75,16 +75,6 @@ brews:
     tap:
       owner: nu0ma
       name: spemu
-    repository:
-      owner: nu0ma
-      name: spemu
-      token: "{{ .Env.GITHUB_TOKEN }}"
-      pull_request:
-        enabled: true
-        base:
-          owner: nu0ma
-          name: spemu
-          branch: main
     directory: homebrew
     homepage: https://github.com/nu0ma/spemu
     description: "DML executor for Google Cloud Spanner Emulator"
@@ -93,6 +83,10 @@ brews:
       system "#{bin}/spemu --help"
     install: |
       bin.install "spemu"
+    pull_request:
+      enabled: true
+      base:
+        branch: main
 
 dockers:
   - image_templates:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -72,6 +72,9 @@ release:
 
 brews:
   - name: spemu
+    tap:
+      owner: nu0ma
+      name: spemu
     repository:
       owner: nu0ma
       name: spemu

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -76,6 +76,12 @@ brews:
       owner: nu0ma
       name: spemu
       token: "{{ .Env.GITHUB_TOKEN }}"
+      pull_request:
+        enabled: true
+        base:
+          owner: nu0ma
+          name: spemu
+          branch: main
     directory: homebrew
     homepage: https://github.com/nu0ma/spemu
     description: "DML executor for Google Cloud Spanner Emulator"


### PR DESCRIPTION
## Summary
Configure GoReleaser to create pull requests for Homebrew formula updates instead of directly committing to the main branch.

## Changes Made
- Added `pull_request` configuration to the `brews` section in `.goreleaser.yml`
  - Enabled PR creation with `enabled: true`
  - Configured to target the main branch
- Created `.github/pull_request_template.md` for standardized PR descriptions
  - Includes general PR sections
  - Added specific checklist for Homebrew formula updates

## Impact
After this change, when a new release is created:
1. GoReleaser will create a PR to update the Homebrew formula
2. The PR will target the main branch
3. This allows for review before merging formula updates

## Test Plan
The configuration will be tested on the next release when GoReleaser runs.